### PR TITLE
Fix race condition in connection handling

### DIFF
--- a/lib/http_tackle/listener.ex
+++ b/lib/http_tackle/listener.ex
@@ -7,7 +7,7 @@ defmodule HttpTackle.Listener do
   end
 
   def call(conn = %{method: "POST"}, options) do
-    {:ok, raw_body, _} = Plug.Conn.read_body(conn)
+    {:ok, raw_body, conn} = Plug.Conn.read_body(conn)
 
     callback_module = Keyword.get(options, :module)
 

--- a/test/integration/massive_request_count.exs
+++ b/test/integration/massive_request_count.exs
@@ -1,0 +1,50 @@
+defmodule HttpTackleTest do
+  use ExUnit.Case
+  doctest HttpTackle
+
+  defmodule HttpTackleConsumer do
+    use HttpTackle,
+      http_port: 8888,
+      amqp_url: "amqp://localhost",
+      exchange: "test-exchange",
+      routing_key: "test-key"
+  end
+
+  defmodule TestService do
+    use Tackle.Consumer,
+      url: "amqp://localhost",
+      exchange: "test-exchange",
+      routing_key: "test-key",
+      service: "test-service"
+
+    def handle_message(message) do
+      File.write("/tmp/messages", message, [:append])
+    end
+  end
+
+  setup do
+    HttpTackleConsumer.start_link
+    TestService.start_link
+
+    :timer.sleep(1000)
+
+    on_exit fn ->
+      :timer.sleep(3000) # wait for unix ports to be free again
+    end
+  end
+
+  test "sending a high number of requests in a short burst" do
+    File.write("/tmp/messages", "", [:write])
+
+    (1..100) |> Enum.each(fn(index) ->
+      IO.puts "Sending request #{index}"
+      HTTPotion.post("http://localhost:8888", body: "##{index}")
+    end)
+
+    :timer.sleep(3000)
+
+    expected_result = (1..100) |> Enum.map(fn(index) -> "##{index}" end) |> Enum.join
+
+    assert File.read!("/tmp/messages") == expected_result
+  end
+end


### PR DESCRIPTION
Everything was working fine for a small number of requests, but for bigger hits, for example 10000 messages in a short burst, the connection's method was sometimes `method: "T"`.

Turns out that the last parameter here is very important:

``` elixir
{:ok, raw_body, _} = Plug.Conn.read_body(conn)
```

because it alters the connection that we use to send replies.

``` elixir
{:ok, raw_body, conn} = Plug.Conn.read_body(conn)
```

Debugged this for N hours -.-

🍻
